### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ If you run into errors, try installing SSH dependencies and re-installing git2r
 
 ```sh
 sudo apt-get install libssh2-1 libssh2-1-dev
-Rscript -e 'devtools::install_cran("git2r", force=TRUE)'
+Rscript -e 'devtools::install_cran("git2r", force = TRUE)'
+```
+
+For Mac OSX use:
+```sh
+brew install libssh2
+brew install libgit2
+install.packages("git2r", type = "source", configure.vars = "autobrew=yes")
 ```
 
 ## Examples


### PR DESCRIPTION
For macOS we need to install dependencies and git2r from sources to enable ssh. More info here: https://github.com/ropensci/git2r/issues/267