### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a Shiny package based on [shiny.react](https://github.com/Appsilon/shiny
 These packages are now private. You need a Github account with access to their repos. Install them from GitHub:
 
 ```R
-devtools::install_git("ssh://git@github.com/Appsilon/shiny.react.git", subdir = "shiny.react")
+devtools::install_git("ssh://git@github.com/Appsilon/shiny.react.git")
 devtools::install_git("ssh://git@github.com/Appsilon/shiny.fluent.git")
 ```
 


### PR DESCRIPTION
Install is failing when run with `subdir = "shiny.react"`.