### PR TITLE
Simplify fluentPage() signature

### DIFF
--- a/R/extensions.R
+++ b/R/extensions.R
@@ -19,29 +19,23 @@ CommandBarItem <- function(text, icon = NULL, subitems = NULL, ...) {
   props
 }
 
-#' Basic Fluent UI page. Replacement for shiny::*Page family of functions.
+#' Basic Fluent UI page
 #'
-#' Creates a Fluent UI page with sensible defaults (included Fabric CSS classes, proper class given to the body tag,
-#' suppressed Bootstrap). You can also use shiny.fluent directly, without using this function.
-#' `bodyContent` does not get inserted as React to allow for flexibility. Use \code{\link{withReact}} or \code{\link{reactOutput}}
-#' to insert React content.
+#' Creates a Fluent UI page with sensible defaults (included Fabric CSS classes, proper class given
+#' to the body tag, suppressed Bootstrap). You can also use shiny.fluent directly, without using
+#' this function. You still need to use \code{\link{withReact}} or \code{\link{reactOutput}}
+#' to insert React components.
 #'
-#' @param bodyContent This argument will be inserted into the body tag directly.
-#' @param ... Additional tags that will be inserted into the page. Useful particularly for including head tag content like CSS.
+#' @param ... The contents of the document body.
 #' @export
-fluentPage <- function(bodyContent, ...){
-  fluidPage(
-    shiny::suppressDependencies("bootstrap"),
-    ...,
+fluentPage <- function(...) {
+  shiny::tags$body(class = "ms-Fabric",
     htmltools::htmlDependency(
-      "office-ui-fabric-core",
-      "11.0.0",
-      list(href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/"),
+      name = "office-ui-fabric-core",
+      version = "11.0.0",
+      src = list(href = "https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/"),
       stylesheet = "fabric.min.css"
     ),
-    shiny::tags$body(
-      class = "ms-Fabric",
-      bodyContent
-    )
+    ...
   )
 }

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -22,14 +22,20 @@ CommandBarItem <- function(text, icon = NULL, subitems = NULL, ...) {
 #' Basic Fluent UI page
 #'
 #' Creates a Fluent UI page with sensible defaults (included Fabric CSS classes, proper class given
-#' to the body tag, suppressed Bootstrap). You can also use shiny.fluent directly, without using
-#' this function. You still need to use \code{\link{withReact}} or \code{\link{reactOutput}}
-#' to insert React components.
+#' to the body tag, suppressed Bootstrap).
+#'
+#' You can also use shiny.fluent directly, without using this function. You still need to use
+#' \code{\link{withReact}} or \code{\link{reactOutput}} to insert React components.
+#'
+#' The Bootstrap library is suppressed by default,
+#' as it doesn't work well with Fluent UI in general.
 #'
 #' @param ... The contents of the document body.
+#' @param suppress_bootstrap Whether to suppress Bootstrap.
 #' @export
-fluentPage <- function(...) {
-  shiny::tags$body(class = "ms-Fabric",
+fluentPage <- function(..., suppress_bootstrap = TRUE) {
+  htmltools::tags$body(class = "ms-Fabric",
+    if (suppress_bootstrap) htmltools::suppressDependencies("bootstrap"),
     htmltools::htmlDependency(
       name = "office-ui-fabric-core",
       version = "11.0.0",

--- a/inst/examples/demo/app.R
+++ b/inst/examples/demo/app.R
@@ -93,13 +93,14 @@ sass(
 )
 
 ui <- fluentPage(
-  withReact(
-    layout(router$ui)
-  ),
   tags$head(
     tags$link(href = "style.css", rel = "stylesheet", type = "text/css"),
     shiny_router_script_tag
-  ))
+  ),
+  withReact(
+    layout(router$ui)
+  )
+)
 
 
 #### SERVER

--- a/man/fluentPage.Rd
+++ b/man/fluentPage.Rd
@@ -4,14 +4,21 @@
 \alias{fluentPage}
 \title{Basic Fluent UI page}
 \usage{
-fluentPage(...)
+fluentPage(..., suppress_bootstrap = TRUE)
 }
 \arguments{
 \item{...}{The contents of the document body.}
+
+\item{suppress_bootstrap}{Whether to suppress Bootstrap.}
 }
 \description{
 Creates a Fluent UI page with sensible defaults (included Fabric CSS classes, proper class given
-to the body tag, suppressed Bootstrap). You can also use shiny.fluent directly, without using
-this function. You still need to use \code{\link{withReact}} or \code{\link{reactOutput}}
-to insert React components.
+to the body tag, suppressed Bootstrap).
+}
+\details{
+You can also use shiny.fluent directly, without using this function. You still need to use
+\code{\link{withReact}} or \code{\link{reactOutput}} to insert React components.
+
+The Bootstrap library is suppressed by default,
+as it doesn't work well with Fluent UI in general.
 }

--- a/man/fluentPage.Rd
+++ b/man/fluentPage.Rd
@@ -2,18 +2,16 @@
 % Please edit documentation in R/extensions.R
 \name{fluentPage}
 \alias{fluentPage}
-\title{Basic Fluent UI page. Replacement for shiny::*Page family of functions.}
+\title{Basic Fluent UI page}
 \usage{
-fluentPage(bodyContent, ...)
+fluentPage(...)
 }
 \arguments{
-\item{bodyContent}{This argument will be inserted into the body tag directly.}
-
-\item{...}{Additional tags that will be inserted into the page. Useful particularly for including head tag content like CSS.}
+\item{...}{The contents of the document body.}
 }
 \description{
-Creates a Fluent UI page with sensible defaults (included Fabric CSS classes, proper class given to the body tag,
-suppressed Bootstrap). You can also use shiny.fluent directly, without using this function.
-\code{bodyContent} does not get inserted as React to allow for flexibility. Use \code{\link{withReact}} or \code{\link{reactOutput}}
-to insert React content.
+Creates a Fluent UI page with sensible defaults (included Fabric CSS classes, proper class given
+to the body tag, suppressed Bootstrap). You can also use shiny.fluent directly, without using
+this function. You still need to use \code{\link{withReact}} or \code{\link{reactOutput}}
+to insert React components.
 }


### PR DESCRIPTION
Make the signature simply `fluentPage(...)`. It is still possible to insert additional content to the head of the document - simply use `fluentPage(head("blabla"))` - Shiny handles this correctly during the rendering.