### PR TITLE
Fix missing `router-server` chunk in st-sales-repos-dashboard vignette

### DIFF
--- a/inst/examples/tutorial/dashboard_layout.R
+++ b/inst/examples/tutorial/dashboard_layout.R
@@ -296,10 +296,11 @@ ui <- fluentPage(
 # ---- server ----
 
 server <- function(input, output, session) {
-  # ---- server-router ----
+
+# ---- router-server ----
   router$server(input, output, session)
 
-  # ---- server-rest ----
+# ---- server-rest ----
   filtered_deals <- reactive({
     if (!is.null(input$selectedPeople) && input$selectedPeople != "") {
       selectedPeopleKeys <- input$selectedPeople


### PR DESCRIPTION
Fixes #16 

Great package, very impressive.

While walking through the tutorials I noticed that there was a missing code chunk in the [st-sales-reps-dashboard](https://appsilon.github.io/shiny.fluent/articles/st-sales-reps-dashboard.html) article at the bottom for the `router-server` code chunk:

![image](https://user-images.githubusercontent.com/32652297/112735588-7dac4000-8f23-11eb-9968-4a00adb64d23.png)

To fix the issue, I adjusted the code in [inst/examples/tutorial/dashboard_layout.R line 299/300](https://github.com/jimbrig/shiny.fluent/blob/1ee00bbbe1512c3f2bebc1ea5ba5761d62d9339a/inst/examples/tutorial/dashboard_layout.R#L300), replacing 

```r
server <- function(input, output, session) {
  # ---- server-router ----
  router$server(input, output, session)

  # ---- server-rest ----
  filtered_deals <- reactive({
```

with

```r
server <- function(input, output, session) {

# ---- router-server ----
  router$server(input, output, session)

# ---- server-rest ----
  filtered_deals <- reactive({
```

Notice that I replaced `# ---- server-router ----` with `# ---- router-server ----` and removed the spacing for the section heading so that the vignette, [st-sales-reps-dashboard.Rmd](https://github.com/Appsilon/shiny.fluent/blob/master/vignettes/st-sales-reps-dashboard.Rmd) can now pickup the proper code chunk (see [line 216](https://github.com/Appsilon/shiny.fluent/blob/338f08c35729444a13dc945b426328c94b2231c3/vignettes/st-sales-reps-dashboard.Rmd#L216)). 

You can view the changed file in the PR [here](https://github.com/Appsilon/shiny.fluent/pull/17/files). Besides rebuilding the vignettes/pkgdown and the package itself this is the only change I made to the code.

## Result 

Now the vignette renders properly and displays the `router-server` code  chunk accordingly. 

To demonstrate I re-deployed the gh-pages in my fork and you can see the result here: <https://jimbrig.github.io/shiny.fluent/articles/st-sales-reps-dashboard.html>.

![image](https://user-images.githubusercontent.com/32652297/112735866-dc25ee00-8f24-11eb-93d1-6b8789525e43.png)

Thanks again for the great package!

Jimmy
