### PR TITLE
Add packages required by examples to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,9 +24,14 @@ Imports:
   shiny.react (>= 0.2.2)
 Suggests:
   dplyr,
+  ggplot2,
+  glue,
   jsonlite,
   knitr,
+  leaflet,
+  plotly,
   purrr,
+  RColorBrewer,
   rmarkdown,
   sass,
   shiny.router,

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -1765,9 +1765,9 @@ callsites@^3.0.0:
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 caniuse-lite@^1.0.30001173:
-  version "1.0.30001179"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz#b0803883b4471a6c62066fb1752756f8afc699c8"
-  integrity sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==
+  version "1.0.30001251"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz"
+  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Fixes #69

Examples may not run due to missing packages. While a regular installation of the package shouldn't install packages like `leaflet` or `shiny.router` it should be possible to install them with the package in order to run examples. 

Changes proposed in this pull request:
- added all packages used by examples to `Suggests` field. Now installing with `dependencies = TRUE` allows running examples
- updated browsers list as suggested by Cypress (E2E tests broke otherwise)

# Screenshots

Not applicable 

# PR checklist

Not applicable