### PR TITLE
Add GITHUB_PAT to CI

### DIFF
--- a/.github/workflows/shiny-fluent-test.yaml
+++ b/.github/workflows/shiny-fluent-test.yaml
@@ -17,6 +17,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
Fixes #79 

Changes proposed in this pull request:
- add GITHUB_PAT environmental variable in `shiny.fluent JS test` workflow to allow installation of `shiny.react` package 

# Screenshots

Not applicable

# PR checklist

Not applicable
