### PR TITLE
Change package maintainer to `support+opensource@appsilon.com`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,9 +3,10 @@ Title: Microsoft Fluent UI for Shiny Apps
 Version: 0.2.1
 Authors@R:
   c(
-    person(given = "Marek", family = "Rogala", role = c("aut", "cre"), email = "marek@appsilon.com"),
+    person(given = "Marek", family = "Rogala", role = "aut", email = "marek@appsilon.com"),
     person(given = "Kamil", family = "Zyla", role = "aut", email = "kamil@appsilon.com"),
-    person(given = "Appsilon sp. z o.o.", role = "cph", email = "support+opensource@appsilon.com")
+    person("Developers", "Appsilon", email = "support+opensource@appsilon.com", role = "cre"),
+    person(family = "Appsilon Sp. z o.o.", role = "cph")
   )
 Description: It provides all controls from Microsoft Fluent UI.
 URL: https://appsilon.github.io/shiny.fluent, https://github.com/appsilon/shiny.fluent


### PR DESCRIPTION
Closes #98 

## Changes proposed in this pull request:
- Change maintainer to `support+opensource@appsilon.com`
- Add copyright holder `Appsilon sp. z o.o.`

## Acceptance criteria:
- [x] Ensure that the CRAN entry contains a link to https://appsilon.github.io/shiny.fluent/
- [x] Use opensource@appsilon.com as maintainer email.

Fields are compliant with [shiny.semantic DESCRIPTION](https://github.com/Appsilon/shiny.semantic/blob/develop/DESCRIPTION) and [semantic.dashboard DESCRIPTION](https://github.com/Appsilon/semantic.dashboard/blob/develop/DESCRIPTION)
