### PR TITLE
Updated missing links in r documentation

### DIFF
--- a/R/documentation.R
+++ b/R/documentation.R
@@ -51,10 +51,10 @@ NULL
 #'
 #' The Announced component currently has the following documented use cases:
 #'
-#' 1. [Quick Actions](#/controls/web/announced/quickactions): Operations such as editing text or deletion that are short enough that they do not require a status during progress.
-#' 2. [Search Results](#/controls/web/announced/searchresults): Appearance of search results such as in contact fields or search boxes.
-#' 3. [Lazy Loading](#/controls/web/announced/lazyloading): "Lazy loading" of page sections that do not appear all at once.
-#' 4. [Bulk Operations](#/controls/web/announced/bulkoperations): Operations that require multiple sub operations, such as the moving of several files.
+#' 1. [Quick Actions](https://developer.microsoft.com/en-us/fluentui#/controls/web/announced/quickactions): Operations such as editing text or deletion that are short enough that they do not require a status during progress.
+#' 2. [Search Results](https://developer.microsoft.com/en-us/fluentui#/controls/web/announced/searchresults): Appearance of search results such as in contact fields or search boxes.
+#' 3. [Lazy Loading](https://developer.microsoft.com/en-us/fluentui#/controls/web/announced/lazyloading): "Lazy loading" of page sections that do not appear all at once.
+#' 4. [Bulk Operations](https://developer.microsoft.com/en-us/fluentui#/controls/web/announced/bulkoperations): Operations that require multiple sub operations, such as the moving of several files.
 #'
 #'
 #' For more details and examples visit the [official docs](https://developer.microsoft.com/en-us/fluentui#/controls/web/Announced).
@@ -1712,9 +1712,9 @@ NULL
 #' @description
 #' In a user interface, an icon is an image that represents an application, a capability, or some other concept or specific entity with meaning for the user. An icon is usually selectable but can also be a nonselectable image, such as a company's logo.
 #'
-#' For a list of icons, visit our [icon documentation](#/styles/web/icons).
+#' For a list of icons, visit our [icon documentation](https://developer.microsoft.com/en-us/fluentui#/styles/web/icons).
 #'
-#' Note that icons are not bundled by default and typically must be loaded by calling `initializeIcons` from the `@uifabric/icons` package at the root of your application. See the [icon documentation](#/styles/web/icons#fabric-react) for more details.
+#' Note that icons are not bundled by default and typically must be loaded by calling `initializeIcons` from the `@uifabric/icons` package at the root of your application. See the [icon documentation](https://developer.microsoft.com/en-us/fluentui#/styles/web/icons#fabric-react) for more details.
 #'
 #'
 #' For more details and examples visit the [official docs](https://developer.microsoft.com/en-us/fluentui#/controls/web/Icon).

--- a/man/Announced.Rd
+++ b/man/Announced.Rd
@@ -23,10 +23,10 @@ Some real-world applications of the component include copying, uploading, or mov
 
 The Announced component currently has the following documented use cases:
 \enumerate{
-\item \href{#/controls/web/announced/quickactions}{Quick Actions}: Operations such as editing text or deletion that are short enough that they do not require a status during progress.
-\item \href{#/controls/web/announced/searchresults}{Search Results}: Appearance of search results such as in contact fields or search boxes.
-\item \href{#/controls/web/announced/lazyloading}{Lazy Loading}: "Lazy loading" of page sections that do not appear all at once.
-\item \href{#/controls/web/announced/bulkoperations}{Bulk Operations}: Operations that require multiple sub operations, such as the moving of several files.
+\item \href{https://developer.microsoft.com/en-us/fluentui#/controls/web/announced/quickactions}{Quick Actions}: Operations such as editing text or deletion that are short enough that they do not require a status during progress.
+\item \href{https://developer.microsoft.com/en-us/fluentui#/controls/web/announced/searchresults}{Search Results}: Appearance of search results such as in contact fields or search boxes.
+\item \href{https://developer.microsoft.com/en-us/fluentui#/controls/web/announced/lazyloading}{Lazy Loading}: "Lazy loading" of page sections that do not appear all at once.
+\item \href{https://developer.microsoft.com/en-us/fluentui#/controls/web/announced/bulkoperations}{Bulk Operations}: Operations that require multiple sub operations, such as the moving of several files.
 }
 
 For more details and examples visit the \href{https://developer.microsoft.com/en-us/fluentui#/controls/web/Announced}{official docs}.

--- a/man/Icon.Rd
+++ b/man/Icon.Rd
@@ -22,9 +22,9 @@ Object with \code{shiny.tag} class suitable for use in the UI of a Shiny app.
 \description{
 In a user interface, an icon is an image that represents an application, a capability, or some other concept or specific entity with meaning for the user. An icon is usually selectable but can also be a nonselectable image, such as a company's logo.
 
-For a list of icons, visit our \href{#/styles/web/icons}{icon documentation}.
+For a list of icons, visit our \href{https://developer.microsoft.com/en-us/fluentui#/styles/web/icons}{icon documentation}.
 
-Note that icons are not bundled by default and typically must be loaded by calling \code{initializeIcons} from the \verb{@uifabric/icons} package at the root of your application. See the \href{#/styles/web/icons#fabric-react}{icon documentation} for more details.
+Note that icons are not bundled by default and typically must be loaded by calling \code{initializeIcons} from the \verb{@uifabric/icons} package at the root of your application. See the \href{https://developer.microsoft.com/en-us/fluentui#/styles/web/icons#fabric-react}{icon documentation} for more details.
 
 For more details and examples visit the \href{https://developer.microsoft.com/en-us/fluentui#/controls/web/Icon}{official docs}.
 The R package cannot handle each and every case, so for advanced use cases


### PR DESCRIPTION
### Changes
- Updated missing links in r documentation
Temporary fix for #187

### How to test
- The links should now open the referenced fluent documentations