### PR TITLE
replace dataset calls in vignettes with box imports

### DIFF
--- a/vignettes/st-shiny-fluent-and-rhino.Rmd
+++ b/vignettes/st-shiny-fluent-and-rhino.Rmd
@@ -15,6 +15,7 @@ editor_options:
 ### Getting started with our development environment
 
 Let us first install and create our `rhino` project structure.
+Note: Ensure Rhino v1.4.0 or later is installed for this tutorial.
 
 To install `rhino`, please run the following in the R console:
 
@@ -136,7 +137,6 @@ ui <- function(id) {
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
     output$datatable <- renderUI({
-      # Note : If you are using `box>=1.1.3`, import datasets directly without using `shiny.fluent::fluentSalesDeals`
       DetailsList(items = fluentSalesDeals)
     })
   })
@@ -234,7 +234,6 @@ ui <- function(id) {
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
     output$datatable <- renderUI({
-      # Note : If you are using `box>=1.1.3`, import datasets directly without using `shiny.fluent::fluentSalesDeals`
       # This issue should be solved in the next `box` release.
       DetailsList(items = fluentSalesDeals, columns = columns)
     })
@@ -292,7 +291,6 @@ ui <- function(id) {
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
     filtered_deals <- reactive({
-      # Note : If you are using `box>=1.1.3`, import datasets directly without using `shiny.fluent::fluentSalesDeals`
       fluentSalesDeals |> filter(
         is_closed | input$includeOpen
       )
@@ -378,7 +376,6 @@ ui <- function(id) {
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
     filtered_deals <- reactive({
-       # Note : If you are using `box>=1.1.3`, import datasets directly without using `shiny.fluent::fluentSalesDeals`
       fluentSalesDeals |> filter(
         is_closed | input$includeOpen
       )
@@ -459,7 +456,6 @@ ui <- function(id) {
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
     filtered_deals <- reactive({
-      # Note : If you are using `box>=1.1.3`, import datasets directly without using `shiny.fluent::fluentSalesDeals`
       fluentSalesDeals |> filter(
         is_closed | input$includeOpen
       )

--- a/vignettes/st-shiny-fluent-and-rhino.Rmd
+++ b/vignettes/st-shiny-fluent-and-rhino.Rmd
@@ -120,7 +120,7 @@ This `app/view/datatable.R` file will be used to display the data table on the U
 
 box::use(
   shiny[div, moduleServer, NS, renderUI, uiOutput],
-  shiny.fluent[DetailsList, Text],
+  shiny.fluent[DetailsList, Text, fluentSalesDeals],
 )
 
 #' @export
@@ -136,15 +136,14 @@ ui <- function(id) {
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
     output$datatable <- renderUI({
-      # Datasets are the only case when you need to use :: in `box`.
-      # This issue should be solved in the next `box` release.
-      DetailsList(items = shiny.fluent::fluentSalesDeals)
+      # Note : If you are using `box>=1.1.3`, import datasets directly without using `shiny.fluent::fluentSalesDeals`
+      DetailsList(items = fluentSalesDeals)
     })
   })
 }
 ```
 
-`fluentSalesDeals` is a dataset available with the `shiny.fluent` package and to use it, we use `::` for directly fetching the dataset from the library. Datasets are the only case when you need to use `::` in `box`.
+`fluentSalesDeals` is a dataset available with the `shiny.fluent` package.
 
 So, here we are using [`DetailsList`](https://appsilon.github.io/shiny.fluent/reference/DetailsList.html) function in the server side to render the table on the UI.
 
@@ -213,7 +212,7 @@ Also, we need to mention in the `DetailsList()` function to only display the nam
 
 box::use(
   shiny[div, moduleServer, NS, renderUI, uiOutput],
-  shiny.fluent[DetailsList, Text],
+  shiny.fluent[DetailsList, Text, fluentSalesDeals],
   tibble[tibble],
 )
 
@@ -235,9 +234,9 @@ ui <- function(id) {
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
     output$datatable <- renderUI({
-      # Datasets are the only case when you need to use :: in `box`.
+      # Note : If you are using `box>=1.1.3`, import datasets directly without using `shiny.fluent::fluentSalesDeals`
       # This issue should be solved in the next `box` release.
-      DetailsList(items = shiny.fluent::fluentSalesDeals, columns = columns)
+      DetailsList(items = fluentSalesDeals, columns = columns)
     })
   })
 }
@@ -267,7 +266,7 @@ So, the `app/view/datatable.R` file now is modified to -
 box::use(
   dplyr[filter],
   shiny[div, moduleServer, NS, reactive, renderUI, uiOutput],
-  shiny.fluent[DetailsList, Text, Toggle.shinyInput],
+  shiny.fluent[DetailsList, Text, Toggle.shinyInput, fluentSalesDeals],
   tibble[tibble],
 )
 
@@ -293,9 +292,8 @@ ui <- function(id) {
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
     filtered_deals <- reactive({
-      # Datasets are the only case when you need to use :: in `box`.
-      # This issue should be solved in the next `box` release.
-      shiny.fluent::fluentSalesDeals |> filter(
+      # Note : If you are using `box>=1.1.3`, import datasets directly without using `shiny.fluent::fluentSalesDeals`
+      fluentSalesDeals |> filter(
         is_closed | input$includeOpen
       )
     })
@@ -350,7 +348,7 @@ We will also style the data table area. The following code does the following -
 box::use(
   dplyr[filter],
   shiny[div, moduleServer, NS, reactive, renderUI, span, uiOutput],
-  shiny.fluent[DetailsList, Stack, Text, Toggle.shinyInput],
+  shiny.fluent[DetailsList, Stack, Text, Toggle.shinyInput, fluentSalesDeals],
   tibble[tibble],
 )
 
@@ -380,9 +378,8 @@ ui <- function(id) {
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
     filtered_deals <- reactive({
-      # Datasets are the only case when you need to use :: in `box`.
-      # This issue should be solved in the next `box` release.
-      shiny.fluent::fluentSalesDeals |> filter(
+       # Note : If you are using `box>=1.1.3`, import datasets directly without using `shiny.fluent::fluentSalesDeals`
+      fluentSalesDeals |> filter(
         is_closed | input$includeOpen
       )
     })
@@ -446,7 +443,7 @@ These modules will be called from the main file.
 box::use(
   dplyr[filter],
   shiny[div, moduleServer, NS, reactive],
-  shiny.fluent[Text, Toggle.shinyInput],
+  shiny.fluent[Text, Toggle.shinyInput, fluentSalesDeals],
 )
 
 #' @export
@@ -462,9 +459,8 @@ ui <- function(id) {
 server <- function(id) {
   moduleServer(id, function(input, output, session) {
     filtered_deals <- reactive({
-      # Datasets are the only case when you need to use :: in `box`.
-      # This issue should be solved in the next `box` release.
-      shiny.fluent::fluentSalesDeals |> filter(
+      # Note : If you are using `box>=1.1.3`, import datasets directly without using `shiny.fluent::fluentSalesDeals`
+      fluentSalesDeals |> filter(
         is_closed | input$includeOpen
       )
     })


### PR DESCRIPTION
In vignettes, dataset calls follow the :: pattern due to a bug in the box package. Since the bug has been fixed and the new version of box is available on CRAN, all :: calls should be replaced with the proper box import.

Changes
- replaced dataset calls in rhino tutorials with box imports